### PR TITLE
Fixed :Td opening multiple windows and added customizable size and pos

### DIFF
--- a/lua/floatingtodo/init.lua
+++ b/lua/floatingtodo/init.lua
@@ -1,32 +1,35 @@
 local M = {}
 
 local default_opts = {
-  target_file = "~/notes/todo.md",
-  border = "single",
+  target_file = '~/notes/todo.md',
+  border = 'single',
+  width = 0.8,
+  height = 0.8,
+  pos_x = 0.5,
+  pos_y = 0.5,
 }
 
 local function expand_path(path)
-  if path:sub(1, 1) == "~" then
-    return os.getenv("HOME") .. path:sub(2)
+  if path:sub(1, 1) == '~' then
+    return os.getenv 'HOME' .. path:sub(2)
   end
   return path
 end
 
-local function center_in(outer, inner)
-  return (outer - inner) / 2
-end
-
 local function win_config(opts)
-  local width = math.min(math.floor(vim.o.columns * 0.8), 64)
-  local height = math.floor(vim.o.lines * 0.8)
+  local width = math.min(math.floor(vim.o.columns * opts.width), 64)
+  local height = math.floor(vim.o.lines * opts.height)
+
+  local col = math.floor((vim.o.columns - width) * opts.pos_x)
+  local row = math.floor((vim.o.lines - height) * opts.pos_y)
 
   return {
-    relative = "editor",
+    relative = 'editor',
     width = width,
     height = height,
-    col = center_in(vim.o.columns, width),
-    row = center_in(vim.o.lines, height),
-    border = opts.border
+    col = col,
+    row = row,
+    border = opts.border,
   }
 end
 
@@ -34,7 +37,7 @@ local function open_floating_file(opts)
   local expanded_path = expand_path(opts.target_file)
 
   if vim.fn.filereadable(expanded_path) == 0 then
-    vim.notify("todo file does not exist at directory: " .. expanded_path, vim.log.levels.ERROR)
+    vim.notify('todo file does not exist at directory: ' .. expanded_path, vim.log.levels.ERROR)
     return
   end
 
@@ -49,23 +52,23 @@ local function open_floating_file(opts)
 
   local win = vim.api.nvim_open_win(buf, true, win_config(opts))
 
-  vim.api.nvim_buf_set_keymap(buf, "n", "q", "", {
+  vim.api.nvim_buf_set_keymap(buf, 'n', 'q', '', {
     noremap = true,
     silent = true,
     callback = function()
-      if vim.api.nvim_get_option_value("modified", { buf = buf }) then
-        vim.notify("save your changes pls", vim.log.levels.WARN)
+      if vim.api.nvim_get_option_value('modified', { buf = buf }) then
+        vim.notify('save your changes pls', vim.log.levels.WARN)
       else
         vim.api.nvim_win_close(0, true)
       end
-    end
+    end,
   })
 end
 
 local function setup_user_commands(opts)
-  opts = vim.tbl_deep_extend("force", default_opts, opts)
+  opts = vim.tbl_deep_extend('force', default_opts, opts)
 
-  vim.api.nvim_create_user_command("Td", function()
+  vim.api.nvim_create_user_command('Td', function()
     open_floating_file(opts)
   end, {})
 end
@@ -75,3 +78,4 @@ M.setup = function(opts)
 end
 
 return M
+

--- a/lua/floatingtodo/init.lua
+++ b/lua/floatingtodo/init.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local win = nil
+
 local default_opts = {
   target_file = '~/notes/todo.md',
   border = 'single',
@@ -34,6 +36,11 @@ local function win_config(opts)
 end
 
 local function open_floating_file(opts)
+  if win ~= nil and vim.api.nvim_win_is_valid(win) then
+    vim.api.nvim_set_current_win(win)
+    return
+  end
+
   local expanded_path = expand_path(opts.target_file)
 
   if vim.fn.filereadable(expanded_path) == 0 then
@@ -50,7 +57,7 @@ local function open_floating_file(opts)
 
   vim.bo[buf].swapfile = false
 
-  local win = vim.api.nvim_open_win(buf, true, win_config(opts))
+  win = vim.api.nvim_open_win(buf, true, win_config(opts))
 
   vim.api.nvim_buf_set_keymap(buf, 'n', 'q', '', {
     noremap = true,
@@ -60,6 +67,7 @@ local function open_floating_file(opts)
         vim.notify('save your changes pls', vim.log.levels.WARN)
       else
         vim.api.nvim_win_close(0, true)
+        win = nil
       end
     end,
   })


### PR DESCRIPTION
Fixed :Td opening multiple windows:
   When you open the todo with :Td multiple times in a row, it will create multiple windows stacked on top of each other, making the todo difficult to close if you leave the todo window but stay in neovim.